### PR TITLE
feat: fix missing email on claims

### DIFF
--- a/pkg/oidc/authorize_callback.go
+++ b/pkg/oidc/authorize_callback.go
@@ -52,12 +52,17 @@ func authorizeCallbackHandler(
 			panic(err)
 		}
 
+		userInfos, err := rp.Userinfo(tokens.AccessToken, "Bearer", tokens.IDTokenClaims.GetSubject(), relyingParty)
+		if err != nil {
+			panic(err)
+		}
+
 		user, err := storage.FindUserBySubject(r.Context(), tokens.IDTokenClaims.GetSubject())
 		if err != nil {
 			user = &auth.User{
 				ID:      uuid.NewString(),
-				Subject: tokens.IDTokenClaims.GetSubject(),
-				Email:   tokens.IDTokenClaims.GetEmail(),
+				Subject: userInfos.GetSubject(),
+				Email:   userInfos.GetEmail(),
 			}
 			if err := storage.SaveUser(r.Context(), *user); err != nil {
 				panic(err)


### PR DESCRIPTION
# Fix missing email on database

On a standard 3 legged flow, the spec say the jwt claims should (or must?) not contains email and other user sensitive data.
In this flow, the oauth2 client is considered secured, and capable of requesting user info using corresponding endpoint.
Therefore, use claims of the access token is not suitable, we need to explicitely query user info to have the email and other sensitive data.
The reason why this has not been seen before is because the OIDC server implementation we used to test is Dex, and Dex seem to deviate a little from the spec.