### PR TITLE
fix: close base64 encoder in DelegatedState.EncodeAsUrlParam

### DIFF
--- a/pkg/delegatedauth/state.go
+++ b/pkg/delegatedauth/state.go
@@ -12,7 +12,11 @@ type DelegatedState struct {
 
 func (s DelegatedState) EncodeAsUrlParam() string {
 	buf := bytes.NewBufferString("")
-	if err := json.NewEncoder(base64.NewEncoder(base64.URLEncoding, buf)).Encode(s); err != nil {
+	encoder := base64.NewEncoder(base64.URLEncoding, buf)
+	if err := json.NewEncoder(encoder).Encode(s); err != nil {
+		panic(err)
+	}
+	if err := encoder.Close(); err != nil {
 		panic(err)
 	}
 	return buf.String()

--- a/pkg/delegatedauth/state_fuzz_test.go
+++ b/pkg/delegatedauth/state_fuzz_test.go
@@ -1,0 +1,41 @@
+package delegatedauth
+
+import (
+	"testing"
+)
+
+func FuzzDecodeDelegatedState(f *testing.F) {
+	// Valid base64-encoded JSON seeds
+	valid := DelegatedState{AuthRequestID: "test-123"}
+	f.Add(valid.EncodeAsUrlParam())
+
+	empty := DelegatedState{AuthRequestID: ""}
+	f.Add(empty.EncodeAsUrlParam())
+
+	// Edge cases: raw strings that are not valid base64/JSON
+	f.Add("")
+	f.Add("not-base64")
+	f.Add("====")
+	f.Add("{}")
+	f.Add("e30=") // base64 of "{}"
+	f.Add("bnVsbA==") // base64 of "null"
+	f.Add(string([]byte{0, 1, 2, 3, 4, 5}))
+	f.Add("eyJhdXRoUmVxdWVzdElEIjoiIn0=") // base64 of {"authRequestID":""}
+
+	f.Fuzz(func(t *testing.T, input string) {
+		result, err := DecodeDelegatedState(input)
+		if err != nil {
+			return
+		}
+
+		// Round-trip: encode then decode should produce the same result
+		encoded := result.EncodeAsUrlParam()
+		result2, err := DecodeDelegatedState(encoded)
+		if err != nil {
+			t.Fatalf("round-trip decode failed: %v", err)
+		}
+		if result.AuthRequestID != result2.AuthRequestID {
+			t.Fatalf("round-trip mismatch: %q != %q", result.AuthRequestID, result2.AuthRequestID)
+		}
+	})
+}

--- a/pkg/delegatedauth/testdata/fuzz/FuzzDecodeDelegatedState/c71785f735fef5ee
+++ b/pkg/delegatedauth/testdata/fuzz/FuzzDecodeDelegatedState/c71785f735fef5ee
@@ -1,0 +1,2 @@
+go test fuzz v1
+string("eyJBdXRocmVxdWVzdElEIjoi08000800In00")


### PR DESCRIPTION
## Summary
- **Fix**: `DelegatedState.EncodeAsUrlParam()` was not calling `Close()` on the `base64.NewEncoder`, which caused the final buffered bytes to be silently dropped. This produced truncated base64 output that could not be decoded back, breaking the encode/decode round-trip.
- **Fuzz test**: Added `FuzzDecodeDelegatedState` which tests round-trip consistency (encode → decode → encode → decode) and discovered this bug within 3 seconds of fuzzing.

## Root cause
`base64.NewEncoder` returns an `io.WriteCloser` that buffers data internally in 3-byte blocks. `Close()` must be called to flush any remaining 1-2 bytes with proper padding. The original code wrote JSON through the encoder but never closed it, losing trailing bytes.

## Test plan
- [x] Fuzz test `FuzzDecodeDelegatedState` passes (120s, 3M+ executions, no failures)
- [x] Previously-failing corpus entry `c71785f735fef5ee` now passes
- [x] `golangci-lint` passes with 0 issues
- [x] All existing tests pass (`go test -race ./pkg/...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling when encoding delegated authentication state to ensure encoder closure failures are detected and reported alongside encoding errors.

* **Tests**
  * Added a fuzz test suite to validate encode/decode roundtrips for delegated authentication state, seeded with normal and edge-case inputs to catch decoding regressions and ensure consistent behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->