### PR TITLE
chore(ci): migrate from Shipfox to Namespace.so runners

### DIFF
--- a/.github/actions/docker/action.yml
+++ b/.github/actions/docker/action.yml
@@ -7,10 +7,8 @@ inputs:
 runs:
   using: composite
   steps:
-  - name: Set up QEMU
-    uses: docker/setup-qemu-action@v4
   - name: Set up Docker Buildx
-    uses: docker/setup-buildx-action@v4
+    uses: namespacelabs/nscloud-setup-buildx-action@v0
   - name: "Put back the git branch into git (Earthly uses it for tagging)"
     shell: bash
     run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
   PR:
     if: github.event_name == 'pull_request'
     name: Check PR Title
-    runs-on: shipfox-2vcpu-ubuntu-2404
+    runs-on: namespace-profile-linux-amd64-2vcpu
     permissions:
       statuses: write
     steps:
@@ -25,9 +25,9 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   Dirty:
-    runs-on: "shipfox-4vcpu-ubuntu-2404"
+    runs-on: "namespace-profile-linux-amd64-4vcpu"
     steps:
-      - uses: 'actions/checkout@v6'
+      - uses: 'namespacelabs/nscloud-checkout-action@v7'
         with:
           fetch-depth: 0
       - name: Setup Nix
@@ -50,9 +50,9 @@ jobs:
           fi
 
   Tests:
-    runs-on: "shipfox-4vcpu-ubuntu-2404"
+    runs-on: "namespace-profile-linux-amd64-4vcpu"
     steps:
-      - uses: 'actions/checkout@v6'
+      - uses: 'namespacelabs/nscloud-checkout-action@v7'
         with:
           fetch-depth: 0
       - name: Setup Nix
@@ -65,10 +65,10 @@ jobs:
           SPEAKEASY_API_KEY: ${{ secrets.SPEAKEASY_API_KEY }}
 
   GoReleaser:
-    runs-on: "shipfox-4vcpu-ubuntu-2404"
+    runs-on: "namespace-profile-linux-amd64-4vcpu"
     if: contains(github.event.pull_request.labels.*.name, 'build-images') || github.ref == 'refs/heads/main' || github.event_name == 'merge_group'
     steps:
-      - uses: 'actions/checkout@v6'
+      - uses: 'namespacelabs/nscloud-checkout-action@v7'
         with:
           fetch-depth: 0
       - name: Setup Nix
@@ -90,7 +90,7 @@ jobs:
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
 
   Deploy:
-    runs-on: "shipfox-2vcpu-ubuntu-2404"
+    runs-on: "namespace-profile-linux-amd64-2vcpu"
     if: contains(github.event.pull_request.labels.*.name, 'deploy-staging') || github.ref == 'refs/heads/main'
     environment: staging
     needs:
@@ -102,7 +102,7 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           version: "latest"
-      - uses: 'actions/checkout@v6'
+      - uses: 'namespacelabs/nscloud-checkout-action@v7'
         with:
           fetch-depth: 0
       - name: Tailscale

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -8,9 +8,9 @@ permissions:
 
 jobs:
   GoReleaser:
-    runs-on: "shipfox-4vcpu-ubuntu-2404"
+    runs-on: "namespace-profile-linux-amd64-4vcpu"
     steps:
-      - uses: 'actions/checkout@v6'
+      - uses: 'namespacelabs/nscloud-checkout-action@v7'
         with:
           fetch-depth: 0
       - name: Setup Nix


### PR DESCRIPTION
## Summary

Migrate CI runners from Shipfox to Namespace.so as part of the org-wide CI infrastructure migration.

### Per-workflow changes
- `runs-on: shipfox-Xvcpu-ubuntu-2404` → `runs-on: namespace-profile-linux-amd64-Xvcpu`
- `actions/checkout@v6` → `namespacelabs/nscloud-checkout-action@v7` (git mirror caching, `filter: tree:0` → `dissociate: true`)
- `docker/setup-qemu-action` removed (Namespace builds AMD64+ARM64 natively without emulation)
- `docker/setup-buildx-action` → `namespacelabs/nscloud-setup-buildx-action@v0` (Remote Builders)

### Pattern A composite (`.github/actions/default/action.yml`)
- `nix-community/cache-nix-action@v7` → `namespacelabs/nscloud-cache-action@v1` with `cache: nix`
- `actions/cache@v5` → `namespacelabs/nscloud-cache-action@v1` (paths preserved)

### Validation
- Reference migration: formancehq/ledger#1336 (4 successful runs measured, GoReleaser validated with multi-arch native build)

## Test plan
- [ ] CI passes on this PR
- [ ] No regression in build duration vs prior shipfox runs
- [ ] `GoReleaser` works (add `build-images` label if needed to trigger)
