### PR TITLE
fix: update CODEOWNERS teams

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,1 @@
-* @formancehq/backend
-* @formancehq/devops
+* @formancehq/engineer @formancehq/platform


### PR DESCRIPTION
## Summary

- replace the removed `@formancehq/backend` team with `@formancehq/engineer`
- replace the removed `@formancehq/devops` team with `@formancehq/platform`
- combine both owners into the effective global CODEOWNERS rule

## Validation

- `git diff --check`
- verified both replacement team slugs exist in the FormanceHQ organization

Draft until the organization-wide repository access changes are validated.